### PR TITLE
unixserver: listening socket is leaked to child 

### DIFF
--- a/unixclient.c
+++ b/unixclient.c
@@ -35,6 +35,8 @@ int do_connect(void)
     die("socket");
   size = sizeof(struct sockaddr_un) + strlen(opt_socket)+1;
   saddr = (struct sockaddr_un*)malloc(size);
+  if(saddr == NULL)
+    die("malloc");
   saddr->sun_family = AF_UNIX;
   strcpy(saddr->sun_path, opt_socket);
   if(connect(s, (struct sockaddr*)saddr, SUN_LEN(saddr)) == -1)

--- a/unixserver.c
+++ b/unixserver.c
@@ -180,6 +180,8 @@ int make_socket()
   mode_t old_umask;
   saddr = (struct sockaddr_un*)malloc(sizeof(struct sockaddr_un) +
 				      strlen(opt_socket) + 1);
+  if(saddr == NULL)
+    die("malloc");
   saddr->sun_family = AF_UNIX;
   strcpy(saddr->sun_path, opt_socket);
   unlink(opt_socket);

--- a/unixserver.c
+++ b/unixserver.c
@@ -245,6 +245,7 @@ void handle_connection(int s)
     log_status();
     break;
   case 0:
+    close(s);
     start_child(fd);
     break;
   default:

--- a/unixserver.c
+++ b/unixserver.c
@@ -213,8 +213,6 @@ void start_child(int fd)
     }
   }
   setup_env(fd, opt_socket);
-  close(0);
-  close(1);
   if(dup2(fd, 0) == -1 || dup2(fd, 1) == -1) {
     perror("dup2");
     exit(-1);


### PR DESCRIPTION
Close the listening socket in the subprocess. Alternatively, the socket
could be marked CLOEXEC.

~~~
$ unixserver /tmp/test.s cat

$ lsof -p $(pgrep unixserver)
COMMAND     PID    USER   FD   TYPE             DEVICE SIZE/OFF    NODE NAME
...
unixserve 31458 msantos    0u   CHR             136,32      0t0      35 /dev/pts/32
unixserve 31458 msantos    1u   CHR             136,32      0t0      35 /dev/pts/32
unixserve 31458 msantos    2u   CHR             136,32      0t0      35 /dev/pts/32
unixserve 31458 msantos    3u  unix 0x0000000086432d0c      0t0 1278235 /tmp/test.s type=STREAM

$ lsof -p $(pgrep -n cat)
COMMAND     PID    USER   FD   TYPE             DEVICE SIZE/OFF    NODE NAME
...
cat     31460 msantos    0u  unix 0x0000000077ac21f6      0t0 1278236 /tmp/test.s type=STREAM
cat     31460 msantos    1u  unix 0x0000000077ac21f6      0t0 1278236 /tmp/test.s type=STREAM
cat     31460 msantos    2u   CHR             136,32      0t0      35 /dev/pts/32
cat     31460 msantos    3u  unix 0x0000000086432d0c      0t0 1278235 /tmp/test.s type=STREAM
~~~

Applying patch:
~~~
unixserve 31679 msantos    0u   CHR             136,32      0t0      35 /dev/pts/32
unixserve 31679 msantos    1u   CHR             136,32      0t0      35 /dev/pts/32
unixserve 31679 msantos    2u   CHR             136,32      0t0      35 /dev/pts/32
unixserve 31679 msantos    3u  unix 0x000000004d433d99      0t0 1273748 /tmp/test.s type=STREAM

cat     31710 msantos    0u  unix 0x0000000065947654      0t0 1273749 /tmp/test.s type=STREAM
cat     31710 msantos    1u  unix 0x0000000065947654      0t0 1273749 /tmp/test.s type=STREAM
cat     31710 msantos    2u   CHR             136,32      0t0      35 /dev/pts/32
~~~